### PR TITLE
Ensure RFFT spectrum is always positive

### DIFF
--- a/dsp.js
+++ b/dsp.js
@@ -822,7 +822,7 @@ RFFT.prototype.forward = function(buffer) {
     spectrum[i] = mag;
   }
 
-  spectrum[0] = bSi * x[0];
+  spectrum[0] = Math.abs(bSi * x[0]);
 
   return spectrum;
 };


### PR DESCRIPTION
Hi @corbanbrook!
The RFFT forward transform sometimes exhibits negative spectrum value for a static item.
That is because of not really measuring the length of phasor as in the loop above, but supposition that zero frequency has positive value, which is not always true.
e.g.

``` js
var N = 16;
var real = new Float32Array(N);
for (var i = 0; i < N; i++) {
    real[i] = Math.sin(10000 * (i / N) / (Math.PI * 2))
}

var dsp = require('dsp.js');
var fft = new dsp.RFFT(N, 44100);
fft.forward(real);
console.log(fft.spectrum);
```

gives

``` sh
 Float32Array [
-0.2007274180650711,
0.29625651240348816,
0.6431688070297241,
0.628587007522583,
0.10844749957323074,
0.04224899411201477,
0.016048559918999672,
0.013186296448111534 ]
```
