### PR TITLE
Fix module check in browser

### DIFF
--- a/dsp.js
+++ b/dsp.js
@@ -2300,7 +2300,7 @@ Reverb.prototype.process = function (interleavedSamples){
   return outputSamples;
 };
 
-if (module && typeof module.exports !== 'undefined') {
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
   module.exports = {
     DSP: DSP,
     DFT: DFT,


### PR DESCRIPTION
The library throws an error when used in the browser, `module not defined`. Hence, I added a more robust check if module is defined.