### PR TITLE
Preserve reference to global this.

### DIFF
--- a/dsp.js
+++ b/dsp.js
@@ -53,17 +53,19 @@ var DSP = {
   TWO_PI:         2*Math.PI
 };
 
+
+var self = this;
 // Setup arrays for platforms which do not support byte arrays
 function setupTypedArray(name, fallback) {
   // check if TypedArray exists
   // typeof on Minefield and Chrome return function, typeof on Webkit returns object.
-  if (typeof this[name] !== "function" && typeof this[name] !== "object") {
+  if (typeof self[name] !== "function" && typeof self[name] !== "object") {
     // nope.. check if WebGLArray exists
-    if (typeof this[fallback] === "function" && typeof this[fallback] !== "object") {
-      this[name] = this[fallback];
+    if (typeof self[fallback] === "function" && typeof self[fallback] !== "object") {
+      self[name] = self[fallback];
     } else {
       // nope.. set as Native JS array
-      this[name] = function(obj) {
+      self[name] = function(obj) {
         if (obj instanceof Array) {
           return obj;
         } else if (typeof obj === "number") {

--- a/dsp.js
+++ b/dsp.js
@@ -2300,7 +2300,7 @@ Reverb.prototype.process = function (interleavedSamples){
   return outputSamples;
 };
 
-if (module && typeof module.exports !== 'undefined') {
+if (typeof module !== 'undefined' && module && module.exports) {
   module.exports = {
     DSP: DSP,
     DFT: DFT,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsp.js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Digital Signal Processing for Javascript",
   "main": "dsp.js",
   "directories": {


### PR DESCRIPTION
This change preserves a reference to the global `this` as `self`
so that module bundlers that change context do not prevent this
package from working correctly. Otherwise, `this` will be `undefined`.